### PR TITLE
Stop plugin from breaking when video files can't be accessed

### DIFF
--- a/packages/gatsby-source-vimeo-all/src/gatsby-node.js
+++ b/packages/gatsby-source-vimeo-all/src/gatsby-node.js
@@ -30,15 +30,22 @@ exports.sourceNodes = async (
     )
   })
 
+  const videoFiles = videos && videos.filter(video => video.files);
+  hasVideoFiles = videoFiles.length !== 0;
+
+  if (!hasVideoFiles) {
+    console.info(
+      'Can\'t access video files through Vimeo API on this account. Won\'t create \"VimeoSrcset\" fragment.'
+    );
+    console.info(
+      'Please make sure that you\'re on a Pro plan and that "private" and "video_files" are in the scope of your token.'
+    );
+  }
+
   videos &&
     videos.map(video => {
-      if (!video.files) {
-        console.warn(
-          "Files key is missing. Please make sure that you've added private and video_files permissions in the acces_token. https://developer.vimeo.com/apps"
-        )
-      }
       const nodeData = {
-        srcset: video.files,
+        srcset: hasVideoFiles ? video.files : false,
         name: video.name,
         width: video.width,
         height: video.height,
@@ -48,7 +55,7 @@ exports.sourceNodes = async (
         user: video.user,
         link: video.link,
         duration: video.duration
-      }
+      };
       createNode({
         // Data for the node.
         ...nodeData,
@@ -69,22 +76,24 @@ exports.sourceNodes = async (
 }
 
 exports.onPreExtractQueries = async ({ store, getNodesByType }) => {
-  const program = store.getState().program
+  if (hasVideoFiles) {
+    const program = store.getState().program
 
-  // Check if there are any Vimeo nodes. If so add fragments for Vimeo.
-  // The fragment will cause an error if there are no Vimeo nodes.
-  if (getNodesByType(`Vimeo`).length == 0) {
-    return
-  }
-
-  // We have Vimeo nodes so let's add our fragments to .cache/fragments.
-  await fs.copyFile(
-    require.resolve(`${__dirname}/src/fragments.js`),
-    `${program.directory}/.cache/fragments/vimeo-fragments.js`,
-    err => {
-      if (err) throw err
+    // Check if there are any Vimeo nodes. If so add fragments for Vimeo.
+    // The fragment will cause an error if there are no Vimeo nodes.
+    if (getNodesByType(`Vimeo`).length == 0) {
+      return
     }
-  )
+
+    // We have Vimeo nodes so let's add our fragments to .cache/fragments.
+    await fs.copyFile(
+      require.resolve(`${__dirname}/src/fragments.js`),
+      `${program.directory}/.cache/fragments/vimeo-fragments.js`,
+      err => {
+        if (err) throw err
+      }
+    )
+  }
 }
 // onPreExtract nodes can be used to add fragments for ex. srcset
 // https://youtu.be/0a5kmU0Dr80?t=462


### PR DESCRIPTION
This pull request fixes the issue raised in #5 .

**A couple points:**
1. I wasn't sure, if I should also create a build as part of the PR.
2. I don't have access to a Vimeo account that allows to expose video files via the API, so I couldn't test if my changes broke something for this use case.
3. I changed the log message from `warn` to `info` to raise awareness without being too alarming. :)

Please let me know if there's anything that needs adjustment and I'll get to it.