### PR TITLE
Increase video limit to 100

### DIFF
--- a/my-default-starter/plugins/gatsby-source-vimeo-all/gatsby-node.js
+++ b/my-default-starter/plugins/gatsby-source-vimeo-all/gatsby-node.js
@@ -30,7 +30,7 @@ exports.sourceNodes = async ({
   const videos = await new Promise((resolve, reject) => {
     client.request({
       method: 'GET',
-      path: '/me/videos' // /me/videos/{id}
+      path: '/me/videos?per_page=100' // /me/videos/{id}
 
     }, (error, body, status_code, headers) => {
       if (error) reject(error);

--- a/my-default-starter/plugins/gatsby-source-vimeo-all/src/gatsby-node.js
+++ b/my-default-starter/plugins/gatsby-source-vimeo-all/src/gatsby-node.js
@@ -21,7 +21,7 @@ exports.sourceNodes = async (
     client.request(
       {
         method: 'GET',
-        path: '/me/videos' // /me/videos/{id}
+        path: '/me/videos?per_page=100' // /me/videos/{id}
       },
       (error, body, status_code, headers) => {
         if (error) reject(error)

--- a/packages/gatsby-source-vimeo-all/gatsby-node.js
+++ b/packages/gatsby-source-vimeo-all/gatsby-node.js
@@ -37,7 +37,7 @@ exports.sourceNodes =
         client.request(
           {
             method: 'GET',
-            path: '/me/videos' // /me/videos/{id}
+            path: '/me/videos?per_page=100' // /me/videos/{id}
           },
           (error, body, status_code, headers) => {
             if (error) reject(error)

--- a/packages/gatsby-source-vimeo-all/src/gatsby-node.js
+++ b/packages/gatsby-source-vimeo-all/src/gatsby-node.js
@@ -23,7 +23,7 @@ exports.sourceNodes = async (
     client.request(
       {
         method: 'GET',
-        path: '/me/videos' // /me/videos/{id}
+        path: '/me/videos?per_page=100' // /me/videos/{id}
       },
       (error, body, status_code, headers) => {
         if (error) reject(error)


### PR DESCRIPTION
By default the API only pulls 25 videos but can be made to pull 100, with this change.

(Should've done this instead of filing an issue!)

